### PR TITLE
small fix

### DIFF
--- a/gentopia/assembler/agent_assembler.py
+++ b/gentopia/assembler/agent_assembler.py
@@ -203,8 +203,8 @@ class AgentAssembler:
         result = []
         for plugin in obj:
             # If referring to a tool class then directly load it
-            if issubclass(plugin.__class__, ToolMetaclass):
-                result.append(plugin())
+            if issubclass(plugin.get('name', "").__class__, ToolMetaclass):
+                result.append(plugin.get('name', "")())
                 continue
 
             # Directly invoke already loaded plugin


### PR DESCRIPTION
When I create a custom agent, and use the custom tool, e.g.:
```
plugins: 
  - name: !tool gentpool.pool.cpp_coding.tool.CppCodeInterpreterTool
```
error occours:
```
~/Gentopia-ai/GentPool$ python3 assemble.py cpp_coding
>>> Assembling agent cpp_coding...
Traceback (most recent call last):
  File "/home/crescentcat/Gentopia-ai/GentPool/assemble.py", line 41, in <module>
    main()
  File "/home/crescentcat/Gentopia-ai/GentPool/assemble.py", line 32, in main
    agent = assembler.get_agent()
  File "/home/crescentcat/Gentopia-ai/Gentopia/gentopia/assembler/agent_assembler.py", line 82, in get_agent
    plugins=self._parse_plugins(config.get('plugins', [])),
  File "/home/crescentcat/Gentopia-ai/Gentopia/gentopia/assembler/agent_assembler.py", line 225, in _parse_plugins
    tool = load_tools(plugin['name'])(**params)
  File "/home/crescentcat/Gentopia-ai/Gentopia/gentopia/tools/__init__.py", line 38, in load_tools
    raise NotImplementedError
NotImplementedError
```
So I made a small fix in `assembler/agent_assembler.py` to solve this. 
The `plugin.__class__` will always return dict so it doesn't work correctly