### PR TITLE
Solved for "TypeError: issubclass() arg 1 must be a class" when using typing.Literal in `embedding.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ test.py
 notebooks/test.ipynb
 .chroma
 node_modules/
+debugging_test/
+assemble.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@ test.py
 notebooks/test.ipynb
 .chroma
 node_modules/
-debugging_test/
-assemble.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/gentopia/memory/embeddings.py
+++ b/gentopia/memory/embeddings.py
@@ -27,6 +27,8 @@ from tenacity import (
 )
 from gentopia.memory.utils import get_from_dict_or_env
 
+from enum import Enum
+
 logger = logging.getLogger(__name__)
 
 
@@ -156,6 +158,9 @@ async def async_embed_with_retry(embeddings: OpenAIEmbeddings, **kwargs: Any) ->
 
     return await _async_embed_with_retry(**kwargs)
 
+class SpecialAllow:
+    class ValueField(str, Enum):
+        VALID_VALUE = "all"
 
 class OpenAIEmbeddings(BaseModel, Embeddings):
     """Wrapper around OpenAI embedding models."""
@@ -173,8 +178,8 @@ class OpenAIEmbeddings(BaseModel, Embeddings):
     embedding_ctx_length: int = 8191
     openai_api_key: Optional[str] = None
     openai_organization: Optional[str] = None
-    allowed_special: Union[Literal["all"], Set[str]] = set()
-    disallowed_special: Union[Literal["all"], Set[str], Sequence[str]] = "all"
+    allowed_special: Union[SpecialAllow.ValueField, Set[str]] = set()
+    disallowed_special: Union[SpecialAllow.ValueField, Set[str], Sequence[str]] = "all"
     chunk_size: int = 1000
     """Maximum number of texts to embed in each batch"""
     max_retries: int = 6


### PR DESCRIPTION
## Description

It will solve the `TypeError` caused by using `typing.Literal` in `embedding.py` because of the forward reference mechanism. Original Error screenshot is attached. 
![Screenshot 2023-11-26 at 6 29 45 PM](https://github.com/Gentopia-AI/Gentopia/assets/35663003/9ff1244f-fa7b-4533-98b7-c0a17225c763)

## Solution

Creating a new class with `enum.Enum` for the literal value to bypass this error, as `Literal` cannot be subclassed and will cause the `TypeError` issue mentioned above. The modified parts were screenshots and attached below.
![Screenshot 2023-11-26 at 6 32 48 PM](https://github.com/Gentopia-AI/Gentopia/assets/35663003/ee03181f-0bef-4ff5-9d5f-b71c7cc2497d)

## Example 

![Screenshot 2023-11-26 at 9 08 12 PM](https://github.com/Gentopia-AI/Gentopia/assets/35663003/5f66fe60-af2e-492b-ab8c-4f1f24cc84c8)

## Misc

(Links, notes, @people, etc.) 

Inspired by this [post](https://github.com/tiangolo/sqlmodel/issues/67)